### PR TITLE
Added policy regarding vacation

### DIFF
--- a/Policy/policies.markdown
+++ b/Policy/policies.markdown
@@ -28,7 +28,7 @@ Each day of vacation taken by a given member counts as though that member had wo
     --------------------------- * vacation days taken to-date
     days elapsed in year
 
-When calculating earnings to-date, this figure is added into the total hours worked by each member, both in `total hours worked by individual` and `total hour worked by current members`.
+When calculating earnings to-date, this figure is added into the total hours worked by each member, both in `total hours worked by individual` and `total hours worked by current members`.
 
 
 Income

--- a/Policy/policies.markdown
+++ b/Policy/policies.markdown
@@ -1,6 +1,7 @@
 Little Weaver Web Collective, LLC Policies
 ==========================================
 
+
 Work
 ----
 
@@ -15,6 +16,19 @@ Each member must work a minimum of 40 hours per four-week pay period. Work hours
 Members may not work more than 60 hours per week, because life outside of work is also important.
 
 Pay periods are four weeks long, starting on a Monday and ending on a Sunday. Pay periods are a part of the fiscal year in which they end. Paychecks will be cut no sooner than the weekly meeting following the end of a pay period, and no later than the Wednesday following the end of the pay period. (There is a delay between when the online request is made and when the checks are actually mailed; this is not accounted for in this policy.)
+
+
+### Vacation
+
+Starting in 2015, each member receives 28 vacation days per year. Vacation days are recorded per pay period, in increments no finer than half-days. It is preferable that use of vacation days be announced at the end of the preceding pay period, and that vacation days be assigned to specific dates when a member will not be working, but this is not required. In the last pay period of the year, any unused vacation days will automatically be added to that pay period.
+
+Each day of vacation taken by a given member counts as though that member had worked a day of average length for that member in that fiscal year. The calculation for vacation hours worked by an individual to-date is:
+
+    total hours worked to-date
+    --------------------------- * vacation days taken to-date
+    days elapsed in year
+
+When calculating earnings to-date, this figure is added into the total hours worked by each member, both in `total hours worked by individual` and `total hour worked by current members`.
 
 
 Income


### PR DESCRIPTION
### Notes 

* Four weeks should be 28 days of vacation, because we do not distinguish between weekdays and weekends.
* I would make a section of the pay spreadsheet for vacation days taken per pay period.
* Half-days don't make sense now but might later. Smaller increments seem silly, though really any decimal portion of a day will be easy to calculate.
* I put it as optional to declare vacation way ahead and assign it to certain days, but we could also make things more required and just waive requirements as necessary.
  * Requiring assigning to certain days might be a good idea, otherwise it won't really feel like vacation.
  * I might like to change it so that you are required to declare a week in advance, or something like that. And we could waive as necessary.
* `days elapsed in year` will probably functionally be calculated as:
  `(number of current pay period) * 28`


### Please comment on

Any changes you would like to make, especially the things I wasn't sure about, as noted above.